### PR TITLE
Tweaks to built-in source viewer

### DIFF
--- a/packages/gscope/src/fileview.c
+++ b/packages/gscope/src/fileview.c
@@ -137,6 +137,10 @@ void FILEVIEW_create(gchar *file_name, gint line)
             // create a new GtkSourceView window
             createFileViewer(windowPtr);
             s_buffer = gtk_text_view_get_buffer(GTK_TEXT_VIEW(windowPtr->srcViewWidget));
+
+            // Create a marker to indicate the matched line
+            gtk_text_buffer_get_iter_at_line (GTK_TEXT_BUFFER (s_buffer), &iter, line - 1);
+            gtk_source_buffer_create_source_mark (GTK_SOURCE_BUFFER (s_buffer), "LineMarker", "LMtype", &iter);
     
             if (viewListBegin == NULL)
             {
@@ -168,6 +172,10 @@ void FILEVIEW_create(gchar *file_name, gint line)
     mark = gtk_text_buffer_get_insert(GTK_TEXT_BUFFER (s_buffer));
     // Scroll to the specified line number
     gtk_text_view_scroll_to_mark(GTK_TEXT_VIEW(windowPtr->srcViewWidget), mark, 0, TRUE, 0, 0.5);
+
+    /* Move the search marker to the specified line */
+    gtk_text_buffer_move_mark_by_name (GTK_TEXT_BUFFER (s_buffer), "LineMarker", &iter);
+
     return;
 }
 
@@ -370,9 +378,6 @@ static gboolean open_file (GtkSourceBuffer *sBuf, const gchar *filename, gint li
     /* move cursor to the specified line */
     gtk_text_buffer_get_iter_at_line (GTK_TEXT_BUFFER (sBuf), &iter, line - 1);
     gtk_text_buffer_place_cursor (GTK_TEXT_BUFFER (sBuf), &iter);
-
-    /* Set a marker on the specified line */
-    gtk_source_buffer_create_source_mark (GTK_SOURCE_BUFFER(sBuf), "LineMarker", "LMtype", &iter);
 
     g_object_set_data_full (G_OBJECT (sBuf),"filename", g_strdup (filename),
                             (GDestroyNotify) g_free);

--- a/packages/gscope/src/fileview.c
+++ b/packages/gscope/src/fileview.c
@@ -180,6 +180,7 @@ static void createFileViewer(ViewWindow *windowPtr)
     GtkSourceBuffer *sBuf;
     GtkSourceLanguageManager *lm;
     GdkPixbuf *fileview_icon_pixbuf;
+    PangoFontDescription *font_desc;
     const gchar * const *lang_dirs;
     static guint x = 400;
     static guint y = 400;
@@ -249,16 +250,14 @@ static void createFileViewer(ViewWindow *windowPtr)
 
     g_signal_connect (GTK_SOURCE_VIEW(sView),"populate-popup",G_CALLBACK(ModifyTextPopUp),windowPtr);
 
-    #if 0   // There's really no good reason to override the font provided by the Theme.
     /* Set default Font name,size */
-    font_desc = pango_font_description_from_string ("mono 8");
+    font_desc = pango_font_description_from_string ("Monospace");
     #ifdef GTK3_BUILD
     gtk_widget_override_font (sView, font_desc);
     #else
     gtk_widget_modify_font (sView, font_desc);
     #endif
     pango_font_description_free (font_desc);
-    #endif
 
     /* Attach the GtkSourceView to the scrolled Window */
     gtk_container_add (GTK_CONTAINER (pScrollWin), GTK_WIDGET (sView));


### PR DESCRIPTION
Several fixes and tweaks to the built-in source viewer window:
- Use the system configured fixed-width font and size
- Move the search marker when double-clicking on a different match that re-uses the same window
- Fix for scrolling the matched line into view on GTK3