### PR TITLE
Fix hard-coded pixmap path in default CSS.

### DIFF
--- a/packages/gscope/src/app_config.c
+++ b/packages/gscope/src/app_config.c
@@ -1303,7 +1303,7 @@ gchar *template =
 "\n"
 "\n#blue_eventbox"
 "\n{"
-"\n    background-image: url('/sirius/tools/gscope/share/gscope/pixmaps/blue-box-background.png');"
+"\n    background-image: url('" PACKAGE_DATA_DIR "/" PACKAGE "/pixmaps/blue-box-background.png');"
 "\n}"
 "\n"
 "\n#header_button,"


### PR DESCRIPTION
Closes issue #7 